### PR TITLE
Add email verification

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -295,3 +295,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/python,django,linux,windows
+
+mailkey.py

--- a/server/WorkoutWithServer/settings.py
+++ b/server/WorkoutWithServer/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 import os
 from pathlib import Path
+import mailkey
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -59,7 +60,6 @@ ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USERNAME_REQUIRED = True
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_AUTHENTICATION_METHOD = 'username'
-ACCOUNT_EMAIL_VERIFICATION = 'none'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
@@ -145,3 +145,26 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Email Verification
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
+EMAIL_HOST = 'smtp.gmail.com'
+
+EMAIL_PORT = '587'
+
+EMAIL_HOST_USER = mailkey.host
+
+EMAIL_HOST_PASSWORD = mailkey.hostpw
+
+EMAIL_USE_TLS = True
+
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+
+ACCOUNT_CONFIRM_EMAIL_ON_GET = True
+
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+
+ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1
+
+ACCOUNT_EMAIL_SUBJECT_PRFEIX = "WorkoutWith"

--- a/server/accounts/urls.py
+++ b/server/accounts/urls.py
@@ -1,6 +1,17 @@
-from django.urls import path, include
+from django.urls import path, include, re_path
+from dj_rest_auth.registration.views import VerifyEmailView, RegisterView
+
+from dj_rest_auth.views import (
+    LoginView, LogoutView, PasswordChangeView,
+    PasswordResetView, PasswordResetConfirmView
+)
+from accounts.views import ConfirmEmailView
 
 urlpatterns = [
     path('', include('dj_rest_auth.urls')),
     path('registration/', include('dj_rest_auth.registration.urls')),
+    path('allauth/', include('allauth.urls')),
+    path('accounts/allauth/', include('allauth.urls')),
+    re_path(r'^account-confirm-email/$', VerifyEmailView.as_view(), name='account_email_verification_sent'),
+    re_path(r'^account-confirm-email/(?P<key>[-:\w]+)/$', ConfirmEmailView.as_view(), name='account_confirm_email')
 ]

--- a/server/accounts/views.py
+++ b/server/accounts/views.py
@@ -1,3 +1,33 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+from allauth.account.models import EmailConfirmation, EmailConfirmationHMAC
 
-# Create your views here.
+
+class ConfirmEmailView(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, *args, **kwargs):
+        self.object = confirmation = self.get_object()
+        confirmation.confirm(self.request)
+        # A React Router Route will handle the failure scenario
+        # return HttpResponseRedirect('/login')
+        return Response('registration success', status=200)
+
+    def get_object(self, queryset=None):
+        key = self.kwargs['key']
+        email_confirmation = EmailConfirmationHMAC.from_key(key)
+        if not email_confirmation:
+            if queryset is None:
+                queryset = self.get_queryset()
+            try:
+                email_confirmation = queryset.get(key=key.lower())
+            except EmailConfirmation.DoesNotExist:
+                # A React Router Route will handle the failure scenario
+                return Response('registration failed', status=400)
+        return email_confirmation
+
+    def get_queryset(self):
+        qs = EmailConfirmation.objects.all_valid()
+        qs = qs.select_related("email_address__user")
+        return qs


### PR DESCRIPTION
## Summary
<!-- 
Describe what does this PR do. You may describe relevant motivation and context.
  ex) Adds new feature of server api consicely. 
-->
Implements email verification for user registration.
## Changes
<!-- 
List changes you've made.
  ex) * Add authorization api for server
      * Change server settings
      * Fix 404 errors
-->
* Add feature of sending verification email with link when user tries to register
* Add feature of verify users who have accessed to mail's url link
* Separate mail account information from settings.py(check additional context below)
## References
<!-- List any references you have looked up. If you haven't, you may keep this section clear. -->
* https://gist.github.com/iMerica/a6a7efd80d49d6de82c7928140676957
* https://github.com/pennersr/django-allauth/blob/master/allauth/account/views.py
* https://moondol-ai.tistory.com/211
## Additional Context
<!-- Please describe any other information about this pull request, if needed. -->
This feature requires Gmail account(email, password), which cannot be controlled by version control.
To pass gmail account to settings.py, add `mailkey.py` file in root project directory(`/server`) with the following format:
```python
host = 'yourmail@gmail.com'
hostpw = 'yourpassword'
```